### PR TITLE
Tacto coding challenge supplier table

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -7,11 +7,16 @@ import { default as React, useEffect } from 'react';
 
 const App: React.FC = () => {
   const rows = useOrganizationTable();
-  const { fetchOrganizations } = useStore(({ fetchOrganizations }) => ({ fetchOrganizations }));
+  const { fetchOrganizations, fetchUsers, fetchDepartments, fetchArticles } = useStore(
+    ({ fetchOrganizations, fetchUsers, fetchDepartments, fetchArticles }) => ({ fetchOrganizations, fetchUsers, fetchDepartments, fetchArticles })
+  );
 
   useEffect(() => {
     ApiHandler.init();
     fetchOrganizations();
+    fetchUsers();
+    fetchDepartments();
+    fetchArticles();
   }, []);
 
   return (

--- a/src/modules/organization_overview/components/OrganizationTable.tsx
+++ b/src/modules/organization_overview/components/OrganizationTable.tsx
@@ -1,13 +1,18 @@
+import { Article } from '@/api';
 import { OrganizationTableRow } from '@/modules/organization_overview/helpers/hooks';
+import { TactoFeedbackColors, TactoNeutralColors } from '@/theme/colors';
 import React from 'react';
 
-import { Table, TableBody, TableCell, TableContainer, TableHead, TableRow } from '@mui/material';
+import AccessAlarmIcon from '@mui/icons-material/AccessAlarm';
+import { Table, TableBody, TableCell, TableContainer, TableHead, TableRow, Chip, Tooltip, Box } from '@mui/material';
 
 interface OrganizationTableProps {
   rows: Array<OrganizationTableRow>;
 }
 
 const OrganizationTable: React.FC<OrganizationTableProps> = ({ rows }) => {
+  const getInRiskArticleTooltipText = (inRiskArticles: Article[]) => inRiskArticles.map((article) => `${article.id} - ${article.name}`).join(', ');
+
   return (
     <TableContainer>
       <Table>
@@ -16,6 +21,9 @@ const OrganizationTable: React.FC<OrganizationTableProps> = ({ rows }) => {
             <TableCell component="th">ID</TableCell>
             <TableCell component="th">Name</TableCell>
             <TableCell component="th"># Users</TableCell>
+            <TableCell component="th">Contact Person</TableCell>
+            <TableCell component="th">Articles</TableCell>
+            <TableCell component="th">Status</TableCell>
           </TableRow>
         </TableHead>
         <TableBody>
@@ -24,6 +32,34 @@ const OrganizationTable: React.FC<OrganizationTableProps> = ({ rows }) => {
               <TableCell>{row.id}</TableCell>
               <TableCell>{row.name}</TableCell>
               <TableCell>{row.numberOfUsers}</TableCell>
+              <TableCell>{row.contactPerson ? `${row.contactPerson.firstName} ${row.contactPerson.lastName} (${row.contactPerson.email})` : '-'}</TableCell>
+              <TableCell>{row.articleCount}</TableCell>
+              <TableCell>
+                {row.inRiskArticles.length > 0 && (
+                  <Tooltip title={`High Supplier Risk:  Article ${getInRiskArticleTooltipText(row.inRiskArticles)}`}>
+                    <Chip
+                      icon={
+                        <Box
+                          sx={{
+                            width: 16,
+                            height: 16,
+                            backgroundColor: TactoNeutralColors.white,
+                            borderRadius: '50%',
+                            display: 'inline-flex',
+                            justifyContent: 'center',
+                            alignItems: 'center',
+                          }}
+                        >
+                          <AccessAlarmIcon sx={{ width: 12, height: 12, color: TactoFeedbackColors.error.main }} />
+                        </Box>
+                      }
+                      label="Article"
+                      color="error"
+                      size="small"
+                    />
+                  </Tooltip>
+                )}
+              </TableCell>
             </TableRow>
           ))}
         </TableBody>

--- a/src/modules/organization_overview/helpers/hooks.ts
+++ b/src/modules/organization_overview/helpers/hooks.ts
@@ -1,5 +1,6 @@
 import { Organization, User, Article } from '@/api';
 import { useStore } from '@/store';
+import { useGetDepartmentByName } from '@/store/departments/hooks';
 import { useOrganizations } from '@/store/organizations/hooks';
 import { useUsersGroupedByOrganizations } from '@/store/users/hooks';
 
@@ -15,12 +16,12 @@ export const useOrganizationTable = (): Array<OrganizationTableRow> => {
 
   const organizations = useOrganizations();
   const userOrgDict = useUsersGroupedByOrganizations();
+  const contactDepartment = useGetDepartmentByName('Management');
 
   return organizations.map((organization) => ({
     ...organization,
     numberOfUsers: userOrgDict[organization.id]?.length || 0,
-    // for simplicity's sake, assume that management department id is always 1
-    contactPerson: (userOrgDict[organization.id] || []).find((user) => user.departmentIds.includes(1)),
+    contactPerson: (userOrgDict[organization.id] || []).find((user) => contactDepartment && user.departmentIds.includes(contactDepartment.id)),
     articleCount: Object.values(articleDict).filter((article) => article.suppliedBy.includes(organization.id)).length,
     inRiskArticles: Object.values(articleDict).filter((article) => article.suppliedBy.length === 1 && article.suppliedBy[0] === organization.id),
   }));

--- a/src/modules/organization_overview/helpers/hooks.ts
+++ b/src/modules/organization_overview/helpers/hooks.ts
@@ -4,6 +4,7 @@ import { useStore } from '@/store';
 import { useGetDepartmentByName } from '@/store/departments/hooks';
 import { useOrganizations } from '@/store/organizations/hooks';
 import { useUsersGroupedByOrganizations } from '@/store/users/hooks';
+import { useMemo } from 'react';
 
 export interface OrganizationTableRow extends Organization {
   numberOfUsers: number;
@@ -19,15 +20,19 @@ export const useOrganizationTable = (): Array<OrganizationTableRow> => {
   const userOrgDict = useUsersGroupedByOrganizations();
   const contactDepartment = useGetDepartmentByName('Management');
 
-  return organizations.map((organization) => {
-    const supplierArticles = findSupplierArticles(Object.values(articleDict), organization.id);
+  return useMemo(
+    () =>
+      organizations.map((organization) => {
+        const supplierArticles = findSupplierArticles(Object.values(articleDict), organization.id);
 
-    return {
-      ...organization,
-      numberOfUsers: userOrgDict[organization.id]?.length || 0,
-      contactPerson: contactDepartment && findContactPerson(userOrgDict[organization.id] || [], contactDepartment),
-      articleCount: supplierArticles.length,
-      inRiskArticles: findInRiskArticles(supplierArticles),
-    };
-  });
+        return {
+          ...organization,
+          numberOfUsers: userOrgDict[organization.id]?.length || 0,
+          contactPerson: contactDepartment && findContactPerson(userOrgDict[organization.id] || [], contactDepartment),
+          articleCount: supplierArticles.length,
+          inRiskArticles: findInRiskArticles(supplierArticles),
+        };
+      }),
+    [articleDict, organizations, userOrgDict, contactDepartment]
+  );
 };

--- a/src/modules/organization_overview/helpers/hooks.ts
+++ b/src/modules/organization_overview/helpers/hooks.ts
@@ -1,16 +1,27 @@
-import { Organization } from '@/api';
+import { Organization, User, Article } from '@/api';
+import { useStore } from '@/store';
 import { useOrganizations } from '@/store/organizations/hooks';
 import { useUsersGroupedByOrganizations } from '@/store/users/hooks';
 
 export interface OrganizationTableRow extends Organization {
   numberOfUsers: number;
+  contactPerson?: User;
+  articleCount: number;
+  inRiskArticles: Article[];
 }
 
 export const useOrganizationTable = (): Array<OrganizationTableRow> => {
+  const { articleDict } = useStore(({ articleDict }) => ({ articleDict }));
+
   const organizations = useOrganizations();
   const userOrgDict = useUsersGroupedByOrganizations();
+
   return organizations.map((organization) => ({
     ...organization,
     numberOfUsers: userOrgDict[organization.id]?.length || 0,
+    // for simplicity's sake, assume that management department id is always 1
+    contactPerson: (userOrgDict[organization.id] || []).find((user) => user.departmentIds.includes(1)),
+    articleCount: Object.values(articleDict).filter((article) => article.suppliedBy.includes(organization.id)).length,
+    inRiskArticles: Object.values(articleDict).filter((article) => article.suppliedBy.length === 1 && article.suppliedBy[0] === organization.id),
   }));
 };

--- a/src/modules/organization_overview/helpers/utils.ts
+++ b/src/modules/organization_overview/helpers/utils.ts
@@ -1,0 +1,9 @@
+import { Article, Department, User } from '@/api';
+
+export const findContactPerson = (organizationUsers: User[], contactDepartment: Department): User | undefined =>
+  organizationUsers.find((user) => contactDepartment && user.departmentIds.includes(contactDepartment.id));
+
+export const findSupplierArticles = (articles: Article[], organizationId: number): Article[] =>
+  articles.filter((article) => article.suppliedBy.includes(organizationId));
+
+export const findInRiskArticles = (supplierArticles: Article[]): Article[] => supplierArticles.filter((article) => article.suppliedBy.length === 1);

--- a/src/store/departments/hooks.ts
+++ b/src/store/departments/hooks.ts
@@ -1,0 +1,10 @@
+import { Department } from '@/api';
+import { useStore } from '@/store';
+import { useMemo } from 'react';
+
+// eslint-disable-next-line import/prefer-default-export
+export const useGetDepartmentByName = (departmentName: string): Department | undefined => {
+  const { departmentDict } = useStore(({ departmentDict }) => ({ departmentDict }));
+
+  return useMemo(() => Object.values(departmentDict).find((department) => department.name === departmentName), [departmentDict]);
+};


### PR DESCRIPTION
<!-- markdownlint-disable MD041-->

## :sparkles: What?

Implement table that displays the suppliers and the complete information

## :thinking: Why?

Issues with the current implementation: 
- number of users always show zero
- Contact person column is missing
- Numbers of articles column is missing
- Status column is missing

## :wrench: How?

- To solve the problem of numbers of users, I added `fetchUsers` in `src/App.tsx` ([see commit](https://github.com/tacto-ai/coding-challenge-supplier-table/pull/30/commits/1937f1b66ad48e9d893d0b1e466ed4fe4a19ad29#diff-26ad4b834941d9b19ebf9db8082bd202aaf72ea0ddea85f5a8a0cb3c729cc6f2R17))
- To solve the the contact person column, I use `.find` to search for user that has management role in `userOrgDict[organization.id]` by checking if the user belongs to the `Management` department. For the first implementation, I used a hardcoded value based on the `Management` id. ([see commit](https://github.com/tacto-ai/coding-challenge-supplier-table/pull/30/commits/1937f1b66ad48e9d893d0b1e466ed4fe4a19ad29#diff-1e253be46b30b0fb395758d7a25bf11b433216b74df14d9607c4411653d30fdeR23)) Note: this will be fix in the following commit 
- To solve the Article count column, I import `articleDict` from the `useStore` and from there filter them and check if the `article.suppliedBy` contains the `id` of an organization ([see commit](https://github.com/tacto-ai/coding-challenge-supplier-table/pull/30/commits/1937f1b66ad48e9d893d0b1e466ed4fe4a19ad29#diff-1e253be46b30b0fb395758d7a25bf11b433216b74df14d9607c4411653d30fdeR24)) 
- To solve the Status column, it does the same thing as Article count column, but it also check if the length of the `suppliedBy` is one.  ([see commit](https://github.com/tacto-ai/coding-challenge-supplier-table/pull/30/commits/1937f1b66ad48e9d893d0b1e466ed4fe4a19ad29#diff-1e253be46b30b0fb395758d7a25bf11b433216b74df14d9607c4411653d30fdeR25))
   - Additionally, the requirement says to only display one article, but I believe that it's possible that one organization can have multiple articles that only they supply. So I also implemented a function to render multiple articles in the Tooltip ([see commit](https://github.com/tacto-ai/coding-challenge-supplier-table/pull/30/commits/1937f1b66ad48e9d893d0b1e466ed4fe4a19ad29#diff-62950325aad9d717e9a9a96516bc12da89167c1724c1eab852e41861db0545b1R14))
- Lastly, all of the transformation implementation only resides in custom hooks such as `useOrganizationTable` and nothing on `OrganizationTable` component. That's because I want to be very clear on the separation of concern that the custom hooks are only for transforming the data, and the concern of the `OrganizationTable` is only to render that data.


## Improvements 🤩 

### Hardcoded department id for contact person ([commit](https://github.com/tacto-ai/coding-challenge-supplier-table/pull/30/commits/795ccc8a92c44bfa9441a5b419a55ae286a7426f))

For the first working prototype, I used a hardcoded value because usually departments don't usually change, so in the beginning I believe that it's safe to assume that the `id` will not change. However this will be problematic and not future proof. So to fix this, I implemented a [new hook](https://github.com/tacto-ai/coding-challenge-supplier-table/pull/30/commits/795ccc8a92c44bfa9441a5b419a55ae286a7426f) to find department by name. 

### Extracting sub transformer functions ([commit](https://github.com/tacto-ai/coding-challenge-supplier-table/pull/30/commits/2be7739afe20a1d73f0fdaa3e87815b21f93bb39))

Instead of having all the transformer function in one place, I decided to extract those sub transformer functions into individual functions. This way it would make the code more readable, easier to test and further separate the concern so it would be easier to reuse somewhere if needed. 

Additionally, this also improved the performance because the previous implementation iterates twice to get the `Articles` and `Status` for high risk suppliers. Instead, the current implementation reuses the value that it gets from filtering `Articles` by organization id and check for those to see if one of them only has one supplier. ([see commit](https://github.com/tacto-ai/coding-challenge-supplier-table/pull/30/commits/2be7739afe20a1d73f0fdaa3e87815b21f93bb39#diff-1e253be46b30b0fb395758d7a25bf11b433216b74df14d9607c4411653d30fdeR23-R30))  


### Wrapping `useOrganizationTable` transformer function with `useMemo` ([commit](https://github.com/tacto-ai/coding-challenge-supplier-table/pull/30/commits/a3a7cf70fba223c551a258a6923c59ad89f6b359))

Although it's not necessary with the current dataset, there's a potential performance issue with `useOrganizationTable` hook if the dataset becomes larger. That's because whenever `OrganizationTable` rerenders, it will call the transformer function again. 


## Further improvements 🚀 

Note that these are just professional opinion and what I would do in my place. 

### Consider using `react-query` 

This would further reduce the boilerplate and prevent `useMemo` all over the codebase because this introduces another layer for state and REST management. 

### Consider using `react-table` 

React table offers a lot of functionality when it comes to table and datagrid. Right now the table is a very simple implementation, but if it gets more complex `react-table` offers built in features and also performance optimization before. 

### Consider using `Shadcn/ui` instead of `MUI`

I understand that MUI offers ready made UI components. However, if further customization is needed, MUI is not that much flexible. ShadCn offers both ready-made components that we can customize the component further. 

### Consider using GraphQL

If the issue of API not meeting the requirement of the Frontend and data aggregation is used a lot of time, then it might make sense to switch to GraphQL instead so that Frontend can have control of the response they needed instead of implementing transformer functions. 

---

## Screenshot

![image](https://github.com/tacto-ai/coding-challenge-supplier-table/assets/1843525/b65b637a-ffb5-43cd-967d-b62a7eb6cc08)



Thank you for coming to my Ted Talk! 
![GIF](https://media.tenor.com/WPxAYVIOHWgAAAAC/uzbek-ozbek.gif)
